### PR TITLE
feat: Use String(describing: error) for detailed logging

### DIFF
--- a/BooksTracker/BooksTrackerApp.swift
+++ b/BooksTracker/BooksTrackerApp.swift
@@ -45,7 +45,7 @@ struct BooksTrackerApp: App {
         } catch {
             // Print detailed error for debugging
             print("❌ ModelContainer creation failed: \(error)")
-            print("❌ Error details: \(error.localizedDescription)")
+            print("❌ Error details: \(String(describing: error))")
 
             #if targetEnvironment(simulator)
             print("💡 Simulator detected - trying persistent fallback")

--- a/BooksTrackerPackage/Sources/BooksTrackerFeature/CSVImport/EnrichmentService.swift
+++ b/BooksTrackerPackage/Sources/BooksTrackerFeature/CSVImport/EnrichmentService.swift
@@ -86,7 +86,7 @@ public final class EnrichmentService {
 
             // Fallback for unknown errors
             print("🚨 Unexpected error enriching '\(searchTitle)': \(error)")
-            return .failure(.apiError(error.localizedDescription))
+            return .failure(.apiError(String(describing: error)))
         }
     }
 


### PR DESCRIPTION
For logging purposes, `error.localizedDescription` is often too generic as it's designed for user-facing messages. To get more detailed debug information, especially for custom error types, it's better to log the full error object. Using `String(describing: error)` will provide a more complete description of the error, which can be very helpful during debugging.