### PR TITLE
feat: Implement in-memory cache to prevent SwiftData crash

### DIFF
--- a/BooksTrackerPackage/Sources/BooksTrackerFeature/EditionMetadataView.swift
+++ b/BooksTrackerPackage/Sources/BooksTrackerFeature/EditionMetadataView.swift
@@ -15,6 +15,7 @@ struct EditionMetadataView: View {
 
     @Environment(\.modelContext) private var modelContext
     @Environment(\.iOS26ThemeStore) private var themeStore
+    @Environment(\.dtoMapper) private var dtoMapper
     @State private var showingStatusPicker = false
     @State private var showingNotesEditor = false
     @FocusState private var isPageFieldFocused: Bool
@@ -408,6 +409,7 @@ struct EditionMetadataView: View {
 
         // If work has no more library entries, delete the work (and cascade to editions/authors)
         if work.userLibraryEntries?.isEmpty == true || work.userLibraryEntries == nil {
+            dtoMapper.removeWorkFromCache(work)
             modelContext.delete(work)
         }
 

--- a/BooksTrackerPackage/Sources/BooksTrackerFeature/SearchModel.swift
+++ b/BooksTrackerPackage/Sources/BooksTrackerFeature/SearchModel.swift
@@ -55,8 +55,8 @@ public final class SearchModel {
     // Pagination state
     private var currentPage: Int = 1
 
-    public init(modelContext: ModelContext) {
-        self.apiService = BookSearchAPIService(modelContext: modelContext)
+    public init(modelContext: ModelContext, dtoMapper: DTOMapper) {
+        self.apiService = BookSearchAPIService(modelContext: modelContext, dtoMapper: dtoMapper)
 
         // Load recent searches from UserDefaults
         if let savedSearches = UserDefaults.standard.array(forKey: "RecentBookSearches") as? [String] {

--- a/BooksTrackerPackage/Sources/BooksTrackerFeature/Services/BookSearchAPIService.swift
+++ b/BooksTrackerPackage/Sources/BooksTrackerFeature/Services/BookSearchAPIService.swift
@@ -13,9 +13,9 @@ public class BookSearchAPIService {
     private let dtoMapper: DTOMapper
     private let logger = Logger(subsystem: "com.oooefam.booksV3", category: "BookSearchAPIService")
 
-    public init(modelContext: ModelContext) {
+    public init(modelContext: ModelContext, dtoMapper: DTOMapper) {
         self.modelContext = modelContext
-        self.dtoMapper = DTOMapper(modelContext: modelContext)
+        self.dtoMapper = dtoMapper
 
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 10.0

--- a/BooksTrackerPackage/Sources/BooksTrackerFeature/Services/DTOMapperEnvironmentKey.swift
+++ b/BooksTrackerPackage/Sources/BooksTrackerFeature/Services/DTOMapperEnvironmentKey.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+private struct DTOMapperKey: EnvironmentKey {
+    static let defaultValue: DTOMapper = {
+        let container = try! ModelContainer(for: Work.self, configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+        return DTOMapper(modelContext: container.mainContext)
+    }()
+}
+
+extension EnvironmentValues {
+    var dtoMapper: DTOMapper {
+        get { self[DTOMapperKey.self] }
+        set { self[DTOMapperKey.self] = newValue }
+    }
+}

--- a/BooksTrackerPackage/Sources/BooksTrackerFeature/SettingsView.swift
+++ b/BooksTrackerPackage/Sources/BooksTrackerFeature/SettingsView.swift
@@ -40,6 +40,7 @@ public struct SettingsView: View {
     @Environment(\.iOS26ThemeStore) private var themeStore
     @Environment(\.modelContext) private var modelContext
     @Environment(FeatureFlags.self) private var featureFlags
+    @Environment(\.dtoMapper) private var dtoMapper
 
     // MARK: - State Management
 
@@ -400,6 +401,9 @@ public struct SettingsView: View {
 
                 // 3. Clear enrichment queue (persisted queue items)
                 EnrichmentQueue.shared.clear()
+
+                // NEW: Clear the deduplication cache
+                dtoMapper.clearCache()
 
                 // 4. Delete all Work objects (CASCADE deletes Editions & UserLibraryEntries automatically)
                 let workDescriptor = FetchDescriptor<Work>()


### PR DESCRIPTION
- Implemented an in-memory cache for `Work` objects in `DTOMapper` to avoid a critical `EXC_BREAKPOINT` crash in SwiftData's reflection metadata system.
- Refactored `DTOMapper` to be a shared instance, injected via the SwiftUI environment, ensuring a single source of truth for the cache.
- Added cache invalidation logic to remove `Work` objects from the cache when they are deleted from the library.
- Corrected the `DTOMapper` initialization to use the environment's `ModelContext`, ensuring it operates on the correct database.