### PR TITLE
Fix critical WebSocket and enrichment bugs affecting all import flows

### DIFF
--- a/BooksTrackerPackage/Sources/BooksTrackerFeature/Enrichment/EnrichmentService.swift
+++ b/BooksTrackerPackage/Sources/BooksTrackerFeature/Enrichment/EnrichmentService.swift
@@ -123,10 +123,12 @@ public final class EnrichmentService {
             // Enhanced error logging for debugging enrichment failures
             print("🚨 Batch enrichment failed: \(error)")
             print("🚨 Error type: \(type(of: error))")
-            
+
             if let urlError = error as? URLError {
                 print("🚨 URLError code: \(urlError.code.rawValue), localized: \(urlError.localizedDescription)")
-            } else if let nsError = error as? NSError {
+            } else {
+                // Bridge to NSError for detailed diagnostics
+                let nsError = error as NSError
                 print("🚨 NSError domain: \(nsError.domain), code: \(nsError.code)")
                 print("🚨 NSError userInfo: \(nsError.userInfo)")
             }

--- a/BooksTrackerPackage/Sources/BooksTrackerFeature/GeminiCSVImport/GeminiCSVImportView.swift
+++ b/BooksTrackerPackage/Sources/BooksTrackerFeature/GeminiCSVImport/GeminiCSVImportView.swift
@@ -409,6 +409,7 @@ public struct GeminiCSVImportView: View {
                         importStatus = .completed(books: books, errors: errors)
                     }
                     webSocketTask?.cancel()
+                    return  // Exit message loop - job is complete
 
                 case "error":
                     if let data = message.data,
@@ -419,6 +420,7 @@ public struct GeminiCSVImportView: View {
                         importStatus = .failed(error)
                     }
                     webSocketTask?.cancel()
+                    return  // Exit message loop - job failed
 
                 default:
                     #if DEBUG


### PR DESCRIPTION
## Summary

Fixes 6 critical bugs discovered after PR #294 merge that broke CSV import, introduced post-completion errors, and prevented enrichment for books without ISBNs.

---

## 🐛 Bug Fixes

### 1️⃣ WebSocket Connection Timeout (CSV Import Broken) ❌→✅

**Issue:** CSV import failed with timeout error -1001  
**Root Cause:** `waitForConnection()` sent string `"PING"` message that backend ignored  
**Fix:** Use native `URLSessionWebSocketTask.sendPing()` for protocol-level PING/PONG  
**Impact:** CSV import, bookshelf scan, enrichment queue all affected  

**Before:**
```swift
try await task.send(.string("PING"))  // Backend ignores application messages
_ = try await task.receive()          // Times out waiting for response
```

**After:**
```swift
try await task.sendPing { error in ... }  // WebSocket protocol PING frame
// Server automatically responds with PONG per RFC 6455
```

---

### 2️⃣ Post-Completion WebSocket Error ⚠️→✅

**Issue:** `"Socket is not connected"` error after successful CSV import  
**Root Cause:** Message loop continued after `cancel()`, tried `receive()` on closed socket  
**Fix:** Add `return` statements after `cancel()` to exit loop cleanly  
**Impact:** Harmless but alarming error logs after every successful import  

---

### 3️⃣ Swift 6.2 Sendable Violations (5 compiler errors) 🛑→✅

**Issue:** Generic type `T` in `withTimeout()` crossed task boundaries without Sendable  
**Fix:** Added `T: Sendable` constraint and `@Sendable` closure attribute  

---

### 4️⃣ NSError Cast Warning ⚠️→✅

**Issue:** Conditional cast `error as? NSError` always succeeds in Swift  
**Fix:** Changed to direct bridge `error as NSError`  

---

### 5️⃣ Unreachable Code Warning ⚠️→✅

**Issue:** `guard maxAttempts > 0` on hardcoded constant `5` was unreachable  
**Fix:** Removed unreachable guard statement  

---

### 6️⃣ **CRITICAL:** Cover Images Missing After CSV Import 📷❌→✅

**Issue:** All CSV imported books had blank covers despite enrichment running  
**Root Cause:** `applyEnrichedData()` skipped entire book if no ISBN via `continue`  
**Fix:** Work-level cover image fallback using field from PR #290  
**Impact:** CSV imports without ISBNs now get cover images  

---

## ✅ Testing

- [x] Build succeeds with zero warnings
- [x] CSV import connects successfully
- [x] No post-completion errors
- [x] All WebSocket handlers verified

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
