### PR TITLE
Migrate to @Observable pattern: SyncCoordinator & WebSocketProgressManager

### DIFF
--- a/BooksTrackerPackage/Sources/BooksTrackerFeature/Common/SyncCoordinator.swift
+++ b/BooksTrackerPackage/Sources/BooksTrackerFeature/Common/SyncCoordinator.swift
@@ -5,12 +5,13 @@ import SwiftUI
 /// Orchestrates multi-step background jobs (CSV import, enrichment)
 /// Uses PollingUtility for backend polling and JobModels for type-safe tracking
 @MainActor
-public final class SyncCoordinator: ObservableObject {
+@Observable
+public final class SyncCoordinator {
 
-    // MARK: - Published Properties
+    // MARK: - Public Properties
 
-    @Published public private(set) var activeJobId: JobIdentifier?
-    @Published public private(set) var jobStatus: [JobIdentifier: JobStatus] = [:]
+    public private(set) var activeJobId: JobIdentifier?
+    public private(set) var jobStatus: [JobIdentifier: JobStatus] = [:]
 
     // MARK: - Singleton
 

--- a/BooksTrackerPackage/Sources/BooksTrackerFeature/Common/WebSocketProgressManager.swift
+++ b/BooksTrackerPackage/Sources/BooksTrackerFeature/Common/WebSocketProgressManager.swift
@@ -36,12 +36,13 @@ public struct ConnectionToken: Sendable {
 /// - Step 2: configureForJob(jobId:) - Bind to specific job after connection ready
 /// - Result: Server processes ONLY after WebSocket is listening
 @MainActor
-public final class WebSocketProgressManager: ObservableObject {
+@Observable
+public final class WebSocketProgressManager {
 
     // MARK: - Properties
 
-    @Published public private(set) var isConnected: Bool = false
-    @Published public private(set) var lastError: Error?
+    public private(set) var isConnected: Bool = false
+    public private(set) var lastError: Error?
 
     private var webSocketTask: URLSessionWebSocketTask?
     private var receiveTask: Task<Void, Never>?


### PR DESCRIPTION
## Summary

Migrated two remaining `ObservableObject` classes to use Swift's modern `@Observable` macro, aligning with project coding standards documented in CLAUDE.md.

**Files Changed:**
- `SyncCoordinator.swift` - Job orchestration coordinator
- `WebSocketProgressManager.swift` - WebSocket connection manager

## Changes

### Before (ObservableObject Pattern)
```swift
@MainActor
public final class SyncCoordinator: ObservableObject {
    @Published public private(set) var activeJobId: JobIdentifier?
    @Published public private(set) var jobStatus: [JobIdentifier: JobStatus] = [:]
}
```

### After (@Observable Pattern)
```swift
@MainActor
@Observable
public final class SyncCoordinator {
    public private(set) var activeJobId: JobIdentifier?
    public private(set) var jobStatus: [JobIdentifier: JobStatus] = [:]
}
```

## Benefits

✅ **Simpler Syntax** - No `@Published` wrappers needed  
✅ **Better Performance** - Fine-grained observation instead of full object invalidation  
✅ **Standards Compliance** - Aligns with Swift 6.2 patterns (CLAUDE.md: "Use @Observable pattern instead of ObservableObject")  
✅ **Low Risk** - Both classes already `@MainActor` isolated, minimal migration impact  

## Testing

- ✅ Zero build warnings
- ✅ Zero build errors  
- ✅ All existing `@MainActor` isolation preserved
- ✅ Full clean build successful

## Context

From Swift 6.2 concurrency audit:
> **Priority:** Medium | **Risk:** Low
> 
> These are already @MainActor isolated, just need syntax migration. Your codebase has excellent Swift 6.2 concurrency compliance! Only 2 files need minor updates to align with your @Observable coding standards.

## Related Documentation

- CLAUDE.md State Management section (lines 252-272)
- Swift 6.2 Concurrency Guide: `docs/CONCURRENCY_GUIDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)